### PR TITLE
Update project to use sync.WaitGroup

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -13,7 +13,6 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-2023080216373
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.4-20250130201111-63bb56e20495.1/go.mod h1:novQBstnxcGpfKf8qGRATqn1anQKwMJIbH5Q581jibU=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1 h1:YhMSc48s25kr7kv31Z8vf7sPUIq5YJva9z1mn/hAt0M=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
-buf.build/gen/go/shortlink-org/shortlink-link-link/protocolbuffers/go v1.36.9-20240420204150-bbba30c24796.1/go.mod h1:4bQ0sc4V6ggyU9AKG+pDG7di7ksHD+Spvaiwanj5JHI=
 buf.build/go/protovalidate v0.12.0 h1:4GKJotbspQjRCcqZMGVSuC8SjwZ/FmgtSuKDpKUTZew=
 buf.build/go/protovalidate v0.12.0/go.mod h1:q3PFfbzI05LeqxSwq+begW2syjy2Z6hLxZSkP1OH/D0=
 cel.dev/expr v0.15.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
@@ -1449,7 +1448,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 h1:8nn+rsCvTq9axyEh382S0PFLBeaFwNsT43IrPWzctRU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1/go.mod h1:viRWSEhtMZqz1rhwmOVKkWl6SwmVowfL9O2YR5gI2PE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
-github.com/IBM/sarama v1.46.1/go.mod h1:ipyOREIx+o9rMSrrPGLZHGuT0mzecNzKd19Quq+Q8AA=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1/xq4SEg5z+VpTgjmNeHwPGRQl7takDI=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
@@ -1953,7 +1951,6 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46/go.mod h1:QNpY22eby74jVhqH4WhDLDwxc/vqsern6pW+u2kbkpc=
-github.com/geldata/gel-go v1.4.3/go.mod h1:M3ssAJdJH5OjwJnFda7mgp3tBDHoFC1zcYjZBwDueYY=
 github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaUCn30Q3bCvANo=
 github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -2231,7 +2228,6 @@ github.com/gostaticanalysis/forcetypeassert v0.1.0 h1:6eUflI3DiGusXGK6X7cCcIgVCp
 github.com/gostaticanalysis/forcetypeassert v0.1.0/go.mod h1:qZEedyP/sY1lTGV1uJ3VhWZ2mqag3IkWsDHVbplHXak=
 github.com/gostaticanalysis/testutil v0.4.0/go.mod h1:bLIoPefWXrRi/ssLFWX1dx7Repi5x3CuviD3dgAZaBU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.4/go.mod h1:1HSPtjU8vLG0jE9JrTdzjgFqdJ/VgN7fvxBNq3luJko=
-github.com/graph-gophers/graphql-go v1.8.0/go.mod h1:23olKZ7duEvHlF/2ELEoSZaY1aNPfShjP782SOoNTyM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -2828,6 +2824,7 @@ github.com/quasilyte/go-ruleguard v0.4.3-0.20240823090925-0fe6f58b47b1/go.mod h1
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/raeperd/recvcheck v0.1.2/go.mod h1:n04eYkwIR0JbgD73wT8wL4JjPC3wm0nFtzBnWNocnYU=
 github.com/redis/rueidis/mock v1.0.60/go.mod h1:XXT8Pl1zgKAu3IjNhdb4M0Z4UjZQyKe72f5kR6RJSZI=
+github.com/redis/rueidis/mock v1.0.66/go.mod h1:rNgRslLT8XAS2lenZP87epjz/PEbiNEp2fI11pNhkUI=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -3191,6 +3188,7 @@ go.opentelemetry.io/otel v1.29.0/go.mod h1:N/WtXPs1CNCUEx+Agz5uouwCba+i+bJGFicT8
 go.opentelemetry.io/otel v1.31.0/go.mod h1:O0C14Yl9FgkjqcCZAsE053C13OaddMYr/hz6clDkEJE=
 go.opentelemetry.io/otel v1.32.0/go.mod h1:00DCVSB0RQcnzlwyTfqtxSm+DRr9hpYrHjNGiBHVQIg=
 go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7zzx9oI=
+go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0 h1:TaB+1rQhddO1sF71MpZOZAuSPW1klK2M8XxfrBMfK7Y=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0/go.mod h1:78XhIg8Ht9vR4tbLNUhXsiOnE2HOuSeKAiAcoVQEpOY=
@@ -3214,6 +3212,7 @@ go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdga
 go.opentelemetry.io/otel/metric v1.31.0/go.mod h1:C3dEloVbLuYoX41KpmAhOqNriGbA+qqH6PQ5E5mUfnY=
 go.opentelemetry.io/otel/metric v1.32.0/go.mod h1:jH7CIbbK6SH2V2wE16W05BHCtIDzauciCRLoc/SyMv8=
 go.opentelemetry.io/otel/metric v1.34.0/go.mod h1:CEDrp0fy2D0MvkXE+dPV7cMi8tWZwX3dmaIhwPOaqHE=
+go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
 go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
 go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
@@ -3224,6 +3223,7 @@ go.opentelemetry.io/otel/sdk v1.29.0/go.mod h1:pM8Dx5WKnvxLCb+8lG1PRNIDxu9g9b9g5
 go.opentelemetry.io/otel/sdk v1.31.0/go.mod h1:TfRbMdhvxIIr/B2N2LQW2S5v9m3gOQ/08KsbbO5BPT0=
 go.opentelemetry.io/otel/sdk v1.32.0/go.mod h1:LqgegDBjKMmb2GC6/PrTnteJG39I8/vJCAP9LlJXEjU=
 go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9qANsCzbyxU=
+go.opentelemetry.io/otel/sdk v1.35.0/go.mod h1:+ga1bZliga3DxJ3CQGg3updiaAJoNECOgJREo9KHGQg=
 go.opentelemetry.io/otel/sdk v1.36.0/go.mod h1:+lC+mTgD+MUWfjJubi2vvXWcVxyr9rmlshZni72pXeY=
 go.opentelemetry.io/otel/sdk/metric v1.31.0/go.mod h1:CRInTMVvNhUKgSAMbKyTMxqOBC0zgyxzW55lZzX43Y8=
 go.opentelemetry.io/otel/sdk/metric v1.32.0/go.mod h1:PWeZlq0zt9YkYAp3gjKZ0eicRYvOh1Gd+X99x6GHpCQ=
@@ -3242,6 +3242,7 @@ go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+M
 go.opentelemetry.io/otel/trace v1.31.0/go.mod h1:TXZkRk7SM2ZQLtR6eoAWQFIHPvzQ06FJAsO1tJg480A=
 go.opentelemetry.io/otel/trace v1.32.0/go.mod h1:+i4rkvCraA+tG6AzwloGaCtkx53Fa+L+V8e9a7YvhT8=
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
+go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
@@ -3249,10 +3250,8 @@ go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v8
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
-go.temporal.io/api v1.53.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
-go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -136,11 +136,7 @@ func (batch *Batch[T]) flushItems() {
 		return
 	}
 
-	batch.wg.Add(1)
-
-	go func(items []*Item[T]) {
-		defer batch.wg.Done()
-
+	batch.wg.Go(func() {
 		// Check cancellation again before proceeding.
 		select {
 		case <-batch.done:
@@ -155,5 +151,5 @@ func (batch *Batch[T]) flushItems() {
 				}
 			}
 		}
-	}(items)
+	})
 }

--- a/pkg/concurrency/channel/merge.go
+++ b/pkg/concurrency/channel/merge.go
@@ -10,16 +10,12 @@ func Merge[T any](items ...<-chan T) <-chan T {
 
 	var wg sync.WaitGroup
 
-	wg.Add(len(items))
-
 	for _, item := range items {
-		go func(c <-chan T) {
-			for n := range c {
+		wg.Go(func() {
+			for n := range item {
 				out <- n
 			}
-
-			wg.Done()
-		}(item)
+		})
 	}
 
 	go func() {

--- a/pkg/concurrency/worker_pool/worker_pool_test.go
+++ b/pkg/concurrency/worker_pool/worker_pool_test.go
@@ -29,17 +29,13 @@ func Test_WorkerPool(t *testing.T) {
 
 	go func() {
 		for range 1000 {
-			wg.Add(1)
 			wp.Push(f)
+			wg.Go(func() {
+				<-wp.Result
+			})
 		}
 
 		close(done)
-	}()
-
-	go func() {
-		for range wp.Result {
-			wg.Done()
-		}
 	}()
 
 	<-done

--- a/pkg/raft/server/server_test.go
+++ b/pkg/raft/server/server_test.go
@@ -60,33 +60,25 @@ func Test_Raft(t *testing.T) {
 
 	// Step 2. We wait for the election process to complete =====================
 	wg := sync.WaitGroup{}
-	wg.Add(1)
 
-	for {
-		if node1.GetStatus() == v1.RaftStatus_RAFT_STATUS_LEADER {
-			log.InfoWithContext(ctx, "Node 1 is the leader")
+	wg.Go(func() {
+		for {
+			if node1.GetStatus() == v1.RaftStatus_RAFT_STATUS_LEADER {
+				log.InfoWithContext(ctx, "Node 1 is the leader")
+				break
+			}
 
-			wg.Done()
+			if node2.GetStatus() == v1.RaftStatus_RAFT_STATUS_LEADER {
+				log.InfoWithContext(ctx, "Node 2 is the leader")
+				break
+			}
 
-			break
+			if node3.GetStatus() == v1.RaftStatus_RAFT_STATUS_LEADER {
+				log.InfoWithContext(ctx, "Node 3 is the leader")
+				break
+			}
 		}
-
-		if node2.GetStatus() == v1.RaftStatus_RAFT_STATUS_LEADER {
-			log.InfoWithContext(ctx, "Node 2 is the leader")
-
-			wg.Done()
-
-			break
-		}
-
-		if node3.GetStatus() == v1.RaftStatus_RAFT_STATUS_LEADER {
-			log.InfoWithContext(ctx, "Node 3 is the leader")
-
-			wg.Done()
-
-			break
-		}
-	}
+	})
 
 	wg.Wait()
 }

--- a/pkg/types/partmap/bench_test.go
+++ b/pkg/types/partmap/bench_test.go
@@ -16,14 +16,12 @@ func BenchmarkStd(b *testing.B) {
 		b.ReportAllocs()
 
 		for i := range b.N {
-			wg.Add(1)
-			go func(i int) {
+			wg.Go(func() {
 				key := strconv.Itoa(i)
 				mu.Lock()
 				m[key] = i
 				mu.Unlock()
-				wg.Done()
-			}(i)
+			})
 		}
 		wg.Wait()
 	})
@@ -38,12 +36,10 @@ func BenchmarkSyncStd(b *testing.B) {
 		b.ReportAllocs()
 
 		for i := range b.N {
-			wg.Add(1)
-			go func(i int) {
+			wg.Go(func() {
 				key := strconv.Itoa(i)
 				m.Store(key, i)
-				wg.Done()
-			}(i)
+			})
 		}
 		wg.Wait()
 	})
@@ -62,14 +58,12 @@ func BenchmarkPartitioned(b *testing.B) {
 		b.ReportAllocs()
 
 		for i := range b.N {
-			wg.Add(1)
-			go func(i int) {
+			wg.Go(func() {
 				key := strconv.Itoa(i)
 				if err := m.Set(key, i); err != nil {
 					b.Errorf("Failed to set value in PartMap: %v", err)
 				}
-				wg.Done()
-			}(i)
+			})
 		}
 		wg.Wait()
 	})


### PR DESCRIPTION
```
## Summary 
Refactored `sync.WaitGroup` usage across the project to leverage the new `wg.Go()` method, simplifying concurrency patterns and reducing boilerplate.

## Details 
This PR updates several files to use the `sync.WaitGroup.Go()` method, available in Go 1.23+. This change streamlines goroutine management by automatically handling `wg.Add(1)` and `wg.Done()` calls, leading to cleaner, more readable, and less error-prone concurrent code.

**Motivation:**
The existing code used the traditional `wg.Add(1)` followed by `go func() { defer wg.Done(); ... }()` pattern. The new `wg.Go(func() { ... })` method provides a more idiomatic and concise way to launch goroutines while integrating with `sync.WaitGroup`, improving maintainability and reducing the chance of missed `wg.Done()` calls.

**Changes include:**
- **`pkg/concurrency/channel/merge.go`**: Replaced manual `wg.Add()` and `wg.Done()` with `wg.Go()` for merging channels.
- **`pkg/concurrency/worker_pool/worker_pool_test.go`**: Updated worker pool tests to use `wg.Go()` for task submission and result waiting.
- **`pkg/batch/batch.go`**: Refactored `flushItems()` to use `batch.wg.Go()` for processing batches.
- **`pkg/raft/server/server_test.go`**: Simplified leader election waiting logic with `wg.Go()`.
- **`pkg/types/partmap/bench_test.go`**: Updated all benchmark functions to use the `wg.Go()` pattern for concurrent map operations.

All affected packages and their tests have been run and are passing, ensuring the refactoring did not introduce regressions.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-48bd8c96-f580-4ef1-ab6e-c20e69cda9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48bd8c96-f580-4ef1-ab6e-c20e69cda9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Adopt Go 1.23’s sync.WaitGroup.Go method across the codebase to replace manual Add/Done calls and simplify goroutine management

Enhancements:
- Migrate channel merging, batch flushing, and worker pool logic to use wg.Go instead of manual WaitGroup.Add/Done
- Remove boilerplate Add/Done patterns in core modules for cleaner and less error-prone concurrency

Tests:
- Update raft server, worker pool, and partmap benchmark tests to launch and wait on goroutines via wg.Go

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 84895365316ed3871fa20562c5903d890f19e8cb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->