### PR TITLE
Update benchmark to use testing.B.Loop

### DIFF
--- a/boundaries/link/internal/infrastructure/repository/crud/mongo/mongo_benchmark_test.go
+++ b/boundaries/link/internal/infrastructure/repository/crud/mongo/mongo_benchmark_test.go
@@ -46,7 +46,7 @@ func BenchmarkMongoSerial(b *testing.B) {
 		store, err := New(ctx, st)
 		require.NoError(b, err, "Could not create store")
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			source, err := getLink()
 			require.NoError(b, err)
 
@@ -66,7 +66,7 @@ func BenchmarkMongoSerial(b *testing.B) {
 		storeBatchMode, err := New(newCtx, st)
 		require.NoError(b, err, "Could not create store in batch mode")
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			source, err := getLink()
 			require.NoError(b, err)
 

--- a/boundaries/link/internal/infrastructure/repository/crud/postgres/postgres_benchmark_test.go
+++ b/boundaries/link/internal/infrastructure/repository/crud/postgres/postgres_benchmark_test.go
@@ -76,7 +76,7 @@ func BenchmarkPostgresSerial(b *testing.B) {
 	b.Run("Create [single]", func(b *testing.B) {
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			source, err := getLink()
 			require.NoError(b, err)
 
@@ -97,7 +97,7 @@ func BenchmarkPostgresSerial(b *testing.B) {
 			b.Fatalf("Could not create store: %s", err)
 		}
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			source, err := getLink()
 			require.NoError(b, err)
 

--- a/boundaries/link/internal/infrastructure/repository/crud/ram/ram_benchmark_test.go
+++ b/boundaries/link/internal/infrastructure/repository/crud/ram/ram_benchmark_test.go
@@ -27,7 +27,7 @@ func BenchmarkRAMSerial(b *testing.B) {
 		// create a db
 		store := Store{}
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			source, err := getLink()
 			require.NoError(b, err)
 
@@ -45,7 +45,7 @@ func BenchmarkRAMSerial(b *testing.B) {
 		// Set config
 		b.Setenv("STORE_MODE_WRITE", strconv.Itoa(options.MODE_BATCH_WRITE))
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			source, err := getLink()
 			require.NoError(b, err)
 

--- a/docs/ADR/decisions/proof/ADR-0007/serialization_bench_test.go
+++ b/docs/ADR/decisions/proof/ADR-0007/serialization_bench_test.go
@@ -27,7 +27,7 @@ var payload = Payload{
 
 func BenchmarkMarshalJSONv2(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := jsonv2.Marshal(payload); err != nil {
 			b.Fatal(err)
 		}
@@ -36,7 +36,7 @@ func BenchmarkMarshalJSONv2(b *testing.B) {
 
 func BenchmarkMarshalSegmentio(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := enc.Marshal(payload); err != nil {
 			b.Fatal(err)
 		}
@@ -47,7 +47,7 @@ func BenchmarkUnmarshalJSONv2(b *testing.B) {
 	data, _ := jsonv2.Marshal(payload)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var out Payload
 		if err := jsonv2.Unmarshal(data, &out); err != nil {
 			b.Fatal(err)
@@ -59,7 +59,7 @@ func BenchmarkUnmarshalSegmentio(b *testing.B) {
 	data, _ := enc.Marshal(payload)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var out Payload
 		if err := enc.Unmarshal(data, &out); err != nil {
 			b.Fatal(err)

--- a/pkg/freeport/freeport_test.go
+++ b/pkg/freeport/freeport_test.go
@@ -31,7 +31,7 @@ func TestGetFreePort(t *testing.T) {
 }
 
 func BenchmarkGetFreePort(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		GetFreePort()
 	}
 }

--- a/pkg/http/middleware/csrf/csrf_test.go
+++ b/pkg/http/middleware/csrf/csrf_test.go
@@ -334,7 +334,7 @@ func BenchmarkMiddleware(b *testing.B) {
 	rr := httptest.NewRecorder()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		protectedHandler.ServeHTTP(rr, req)
 	}
 }
@@ -355,7 +355,7 @@ func BenchmarkMiddlewareWithOrigin(b *testing.B) {
 	rr := httptest.NewRecorder()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		protectedHandler.ServeHTTP(rr, req)
 	}
 }


### PR DESCRIPTION
## Summary
Updated Go benchmark functions across the codebase to utilize the `testing.B.Loop()` method introduced in Go 1.24 for improved performance and clarity.

## Details
- Replaced traditional `for i := 0; i < b.N` and `for i := range b.N` loops with `for b.Loop()` in all serial benchmark functions.
- For concurrent benchmarks in `pkg/types/partmap/bench_test.go`, `b.Loop()` was adopted, and `sync/atomic` counters were introduced to generate unique values for each iteration, ensuring correct behavior in parallel scenarios where an explicit index is no longer available from the loop construct.
- Verified that `for pb.Next()` patterns in parallel benchmarks using `*testing.PB` were correctly preserved, as this remains the appropriate pattern for parallel benchmarking.
- This change aligns with Go 1.24 best practices, offering a faster and less error-prone way to write benchmarks.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9a026c9-bfd5-4392-82da-31e3825b3131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9a026c9-bfd5-4392-82da-31e3825b3131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

